### PR TITLE
USB-related printf_verbose() missing newlines added.

### DIFF
--- a/teensy_loader_cli.c
+++ b/teensy_loader_cli.c
@@ -229,7 +229,7 @@ usb_dev_handle * open_usb_device(int vid, int pid)
 			if (dev->descriptor.idProduct != pid) continue;
 			h = usb_open(dev);
 			if (!h) {
-				printf_verbose("Found device but unable to open");
+				printf_verbose("Found device but unable to open\n");
 				continue;
 			}
 			#ifdef LIBUSB_HAS_GET_DRIVER_NP
@@ -238,7 +238,7 @@ usb_dev_handle * open_usb_device(int vid, int pid)
 				r = usb_detach_kernel_driver_np(h, 0);
 				if (r < 0) {
 					usb_close(h);
-					printf_verbose("Device is in use by \"%s\" driver", buf);
+					printf_verbose("Device is in use by \"%s\" driver\n", buf);
 					continue;
 				}
 			}
@@ -249,7 +249,7 @@ usb_dev_handle * open_usb_device(int vid, int pid)
 			r = usb_claim_interface(h, 0);
 			if (r < 0) {
 				usb_close(h);
-				printf_verbose("Unable to claim interface, check USB permissions");
+				printf_verbose("Unable to claim interface, check USB permissions\n");
 				continue;
 			}
 			return h;
@@ -590,7 +590,7 @@ void init_hid_manager(void)
 		IOHIDManagerUnscheduleFromRunLoop(hid_manager,
 			CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
 		CFRelease(hid_manager);
-		printf_verbose("Error opening HID Manager");
+		printf_verbose("Error opening HID Manager\n");
 	}
 }
 


### PR DESCRIPTION
Without these, output under USB error conditions looks like:

```
$ teensy_loader_cli --mcu=mk20dx256 -w -v blink_slow_Teensy31.hex
Teensy Loader, Command Line, Version 2.0
Read "blink_slow_Teensy31.hex": 14324 bytes, 5.5% usage
Unable to claim interface, check USB permissionsWaiting for Teensy device...
 (hint: press the reset button)
Unable to claim interface, check USB permissionsUnable to claim interface, check USB permissionsUnable to …
```