### PR TITLE
Patch for Mac OS HID access

### DIFF
--- a/teensy_loader_cli.c
+++ b/teensy_loader_cli.c
@@ -246,12 +246,12 @@ usb_dev_handle * open_usb_device(int vid, int pid)
 			// Mac OS-X - removing this call to usb_claim_interface() might allow
 			// this to work, even though it is a clear misuse of the libusb API.
 			// normally Apple's IOKit should be used on Mac OS-X
-			r = usb_claim_interface(h, 0);
-			if (r < 0) {
-				usb_close(h);
-				printf_verbose("Unable to claim interface, check USB permissions\n");
-				continue;
-			}
+			// r = usb_claim_interface(h, 0);
+			// if (r < 0) {
+			// 	usb_close(h);
+			// 	printf_verbose("Unable to claim interface, check USB permissions\n");
+			// 	continue;
+			// }
 			return h;
 		}
 	}


### PR DESCRIPTION
These lines will cause HID access problems when compile with libusb.
It's better to comment out these lines as default.