### PR TITLE
Added Make target for MACOSX and USE_LIBUSB combination.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ OS ?= LINUX
 #OS ?= WINDOWS
 #OS ?= MACOSX
 #OS ?= BSD
+USE_LIBUSB ?= YES
 
 ifeq ($(OS), LINUX)  # also works on FreeBSD
 CC ?= gcc
@@ -18,6 +19,13 @@ teensy_loader_cli.exe: teensy_loader_cli.c
 
 
 else ifeq ($(OS), MACOSX)
+ifeq ($(USE_LIBUSB), YES)
+CC ?= gcc
+CFLAGS ?= -O2 -Wall
+teensy_loader_cli: teensy_loader_cli.c
+	$(CC) $(CFLAGS) -s -DUSE_LIBUSB -DMACOSX -o teensy_loader_cli teensy_loader_cli.c -lusb -I /usr/local/include -L/usr/local/lib
+	 
+else
 CC ?= gcc
 SDK ?= $(shell xcrun --show-sdk-path)
 #SDK ?= /Developer/SDKs/MacOSX10.5.sdk  # the old way...
@@ -25,6 +33,7 @@ CFLAGS ?= -O2 -Wall
 teensy_loader_cli: teensy_loader_cli.c
 	$(CC) $(CFLAGS) -DUSE_APPLE_IOKIT -isysroot $(SDK) -o teensy_loader_cli teensy_loader_cli.c -Wl,-syslibroot,$(SDK) -framework IOKit -framework CoreFoundation
 
+endif
 
 else ifeq ($(OS), BSD)  # works on NetBSD and OpenBSD
 CC ?= gcc

--- a/teensy_loader_cli.c
+++ b/teensy_loader_cli.c
@@ -254,12 +254,15 @@ usb_dev_handle * open_usb_device(int vid, int pid)
 			// Mac OS-X - removing this call to usb_claim_interface() might allow
 			// this to work, even though it is a clear misuse of the libusb API.
 			// normally Apple's IOKit should be used on Mac OS-X
+			#if !defined(MACOSX)
 			r = usb_claim_interface(h, 0);
 			if (r < 0) {
 				usb_close(h);
 				printf_verbose("Unable to claim interface, check USB permissions\n");
 				continue;
 			}
+			#endif
+      
 			return h;
 		}
 	}


### PR DESCRIPTION
Hello,

I created patch for the same issue which was mentioned in https://github.com/PaulStoffregen/teensy_loader_cli/pull/19 but without breaking anything for other platforms. 

In later time I'll look into providing proper OSX implementation but for now merging this pr would be very helpful for all PlatformIO users as it uses `teensy_loader_cli` to upload .hex to the board.

Is implementation of Teensy Loader GUI utility, used by Arduino IDE open sourced? I can't find it anywhere and I'd like to look at details there while making OSX implementation for CLI. Clearly everything is solved there.

Best regards,
Oskar Gargas