### PR TITLE
In case of missing macOS SDK (Xcode), make instructs the user and exits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ SDK ?= $(shell xcrun --show-sdk-path)
 #SDK ?= /Developer/SDKs/MacOSX10.6.sdk  # the old way...
 CFLAGS ?= -O2 -Wall
 teensy_loader_cli: teensy_loader_cli.c
+ifeq ($(SDK),)
+	$(error SDK was not found. To use this type of compilation please install Xcode)
+endif
 	$(CC) $(CFLAGS) -DUSE_APPLE_IOKIT -isysroot $(SDK) -o teensy_loader_cli teensy_loader_cli.c -Wl,-syslibroot,$(SDK) -framework IOKit -framework CoreFoundation
 
 endif


### PR DESCRIPTION
Users of OSX that have not yet installed Xcode will have an empty ```$SDK``` variable  (```xcrun --show-sdk-path``` returns empty, see listing), which will expand in a malformatted compilation line, which returns a misleading error message (see listing).  
 
An error message blocks this situation and a clear error message instructs the user on installing Xcode. 

### before

```shell
teensy_loader_cli >>> make
cc -O2 -Wall -DUSE_APPLE_IOKIT -isysroot  -o teensy_loader_cli teensy_loader_cli.c -Wl,-syslibroot, -framework IOKit -framework CoreFoundation
clang: error: no such file or directory: 'teensy_loader_cli'
clang: warning: no such sysroot directory: '-o'
make: *** [teensy_loader_cli] Error 1

teensy_loader_cli >>> xcrun --show-sdk-path

teensy_loader_cli >>> 
```

### After

```shell
teensy_loader_cli >>> make
Makefile:37: *** SDK was not found. To use this type of compilation please install Xcode.  Stop.
```

### Impact
All other compilations (LINUX, WINDOWS, MACOSX using USE_LIBUSB=yes, BSD) are not affected by this change. 

Available for any demand for change, or feedback, please feel free to modify it.