### PR TITLE
set correct write_size for teensy LC/3.X to fix boot only mode

### DIFF
--- a/teensy_loader_cli.c
+++ b/teensy_loader_cli.c
@@ -90,7 +90,8 @@ const char *filename=NULL;
 int main(int argc, char **argv)
 {
 	unsigned char buf[2048];
-	int num, addr, r, write_size=block_size+2;
+	int num, addr, r, write_size;
+
 	int first_block=1, waited=0;
 
 	// parse command line arguments
@@ -103,13 +104,19 @@ int main(int argc, char **argv)
 	}
 	printf_verbose("Teensy Loader, Command Line, Version 2.1\n");
 
+	if (block_size == 512 || block_size == 1024) {
+		write_size = block_size + 64;
+	} else {
+		write_size = block_size + 2;
+	};
+
 	if (boot_only) {
 		if (! teensy_open()) {
 			die("Could not find HalfKay");
 		}
 		printf_verbose("Found HalfKay Bootloader\n");
 
-		boot(buf, block_size+2);
+		boot(buf, write_size);
 		exit(0);
 	}
 


### PR DESCRIPTION
While digging around the code (Thanks!) I was having an issue getting the boot only option to work on a 3.2.

The issue was the boot only option wouldn't cause the teensy to start. I noticed that the buffer length was different for boot only vs boot after programming (1024 + 2 vs 1024 + 64).

I think this commit should fix the issue. I've tested it on the 3.2 and the boot only option now works.