### PR TITLE
Allow use of -b with other switches (especially -w).

### DIFF
--- a/rebootor/usb.c
+++ b/rebootor/usb.c
@@ -70,7 +70,7 @@ static const uint8_t PROGMEM endpoint_config_table[] = {
 // spec and relevant portions of any USB class specifications!
 
 
-static uint8_t PROGMEM device_descriptor[] = {
+static const uint8_t PROGMEM device_descriptor[] = {
 	18,					// bLength
 	1,					// bDescriptorType
 	0x00, 0x02,				// bcdUSB
@@ -87,7 +87,7 @@ static uint8_t PROGMEM device_descriptor[] = {
 	1					// bNumConfigurations
 };
 
-static uint8_t PROGMEM rawhid_hid_report_desc[] = {
+static const uint8_t PROGMEM rawhid_hid_report_desc[] = {
 	0x06, 0x00, 0xFF,
 	0x0A, 0x00, 0x01,
 	0xA1, 0x01,				// Collection 0x01
@@ -103,7 +103,7 @@ static uint8_t PROGMEM rawhid_hid_report_desc[] = {
 
 #define CONFIG1_DESC_SIZE        (9+9+9+7)
 #define RAWHID_HID_DESC_OFFSET   (9+9)
-static uint8_t PROGMEM config1_descriptor[CONFIG1_DESC_SIZE] = {
+static const uint8_t PROGMEM config1_descriptor[CONFIG1_DESC_SIZE] = {
 	// configuration descriptor, USB spec 9.6.3, page 264-266, Table 9-10
 	9, 					// bLength;
 	2,					// bDescriptorType;
@@ -151,17 +151,17 @@ struct usb_string_descriptor_struct {
 	uint8_t bDescriptorType;
 	int16_t wString[];
 };
-static struct usb_string_descriptor_struct PROGMEM string0 = {
+static const struct usb_string_descriptor_struct PROGMEM string0 = {
 	4,
 	3,
 	{0x0409}
 };
-static struct usb_string_descriptor_struct PROGMEM string1 = {
+static const struct usb_string_descriptor_struct PROGMEM string1 = {
 	sizeof(STR_MANUFACTURER),
 	3,
 	STR_MANUFACTURER
 };
-static struct usb_string_descriptor_struct PROGMEM string2 = {
+static const struct usb_string_descriptor_struct PROGMEM string2 = {
 	sizeof(STR_PRODUCT),
 	3,
 	STR_PRODUCT
@@ -169,7 +169,7 @@ static struct usb_string_descriptor_struct PROGMEM string2 = {
 
 // This table defines which descriptor data is sent for each specific
 // request from the host (in wValue and wIndex).
-static struct descriptor_list_struct {
+static const struct descriptor_list_struct {
 	uint16_t	wValue;
 	uint16_t	wIndex;
 	const uint8_t	*addr;


### PR DESCRIPTION
I'm setting up for programming a Teensy on Linux for the first time. After installing the udev rule and building teensy_loader_cli I wanted to test if teensy_loader_cli could find and communicate with my teensy, so I tried teensy_loader_cli --mcu=atmega32u4 -v -w -b, but got the error message "Could not find HalfKay", which confused me since I had not even plugged in the teensy, yet and was expecting -w to wait for me to do so. I checked the source code and saw that -b ignores all other switches. Well, I fixed that.