### PR TITLE
T4

### DIFF
--- a/teensy_loader_cli.c
+++ b/teensy_loader_cli.c
@@ -1063,6 +1063,7 @@ static const struct {
 	{"mk20dx256",   262144,  1024},
 	{"mk66fx1m0",  1048576,  1024},
 	{"mk64fx512",   524288,  1024},
+	{"imxrt1062",  2031616,  1024},
 
 	// Add duplicates that match friendly Teensy Names
 	// Match board names in boards.txt
@@ -1073,6 +1074,7 @@ static const struct {
 	{"TEENSY31",   262144,  1024},
 	{"TEENSY35",   524288,  1024},
 	{"TEENSY36",  1048576,  1024},
+	{"TEENSY40",  2031616,  1024},
 #endif
 	{NULL, 0, 0},
 };


### PR DESCRIPTION
Paul - You might want to take a look and see if this all makes sense. 

First I added the T40 definitions as board types.

Ran into issues that the T40 has an extended address range that is bigger than max size that this program was configured to handle.

@Jonathan changed the code to not use the extended address to index into the array, but add it on at the end when you are programming, which appeared to work. 

But I was concerned that there could be multiple extended address records, in which case they would collide and be wrong.  This code remembers the smallest one defined and everything is based off the smallest address.  If a larger offset was used first, it moves the data down by the offset of the difference between the earlier lowest address and the new address. 

Tested simple blink program on T4 (two  short blinks then longer delay) and it appears to work.  Also tested I could still update a T3.6. 