### PR TITLE
Add Teensy 4.1 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,17 +24,27 @@ A typical usage from the command line may look like this:
 Required command line parameters:
 
 ```
---mcu=<MCU> : Specify Processor. You must specify the target processor. This syntax is the same as used by gcc, which makes integrating with your Makefile easier. Valid options are:
+--mcu=<MCU> : Specify Processor. You must specify the target processor. This syntax is the same as used by gcc, which makes integrating with your Makefile easier, we also now support passing in a logical name. Valid options are:
 --mcu=imxrt1062 : 	Teensy 4.0
 --mcu=mk66fx1m0 : 	Teensy 3.6
 --mcu=mk64fx512 : 	Teensy 3.5
 --mcu=mk20dx256 : 	Teensy 3.2 & 3.1
 --mcu=mk20dx128 : 	Teensy 3.0
 --mcu=mkl26z64 : 	Teensy LC
---mcu=at90usb1286 : 	Teensy++ 2.0
+--mcu=at90usb1286 : Teensy++ 2.0
 --mcu=atmega32u4 : 	Teensy 2.0
 --mcu=at90usb646 : 	Teensy++ 1.0
 --mcu=at90usb162 : 	Teensy 1.0
+--mcu=TEENSY2	: Teensy 2.0
+--mcu=TEENSY2PP	: Teensy++ 2.0
+--mcu=TEENSYLC	: Teensy LC
+--mcu=TEENSY30	: Teensy 3.0
+--mcu=TEENSY31	: Teensy 3.1
+--mcu=TEENSY32	: Teensy 3.2
+--mcu=TEENSY35	: Teensy 3.5
+--mcu=TEENSY36	: Teensy 3.6
+--mcu=TEENSY40	: Teensy 4.0
+--mcu=TEENSY41	: Teensy 4.1
 ```
 
 Caution: HEX files compiled with USB support must be compiled for the correct chip. If you load a file built for a different chip, often it will hang while trying to initialize the on-chip USB controller (each chip has a different PLL-based clock generator). On some PCs, this can "confuse" your USB port and a cold reboot may be required to restore USB functionality. When a Teensy has been programmed with such incorrect code, the reset button must be held down BEFORE the USB cable is connected, and then released only after the USB cable is fully connected.

--- a/teensy_loader_cli.c
+++ b/teensy_loader_cli.c
@@ -102,7 +102,7 @@ int main(int argc, char **argv)
 	if (!code_size) {
 		usage("MCU type must be specified");
 	}
-	printf_verbose("Teensy Loader, Command Line, Version 2.1\n");
+	printf_verbose("Teensy Loader, Command Line, Version 2.2\n");
 
 	if (block_size == 512 || block_size == 1024) {
 		write_size = block_size + 64;
@@ -1081,6 +1081,7 @@ static const struct {
 	{"TEENSY35",   524288,  1024},
 	{"TEENSY36",  1048576,  1024},
 	{"TEENSY40",  2031616,  1024},
+	{"TEENSY41",  8126464,  1024},
 #endif
 	{NULL, 0, 0},
 };


### PR DESCRIPTION
I only added by logical name as it also is imxrt1062 we can add in other as well.

Also updated readme to show logical names...
Again wonder if we should add or change the logical names
to be like: ARDUINO_TEENSY41

Like the builds now use