### PR TITLE
Send complete buffer for soft_reboot

### DIFF
--- a/teensy_loader_cli.c
+++ b/teensy_loader_cli.c
@@ -341,8 +341,8 @@ int soft_reboot(void)
 		return 0;
 	}
 
-	char reboot_command = 134;
-	int response = usb_control_msg(serial_handle, 0x21, 0x20, 0, 0, &reboot_command, 1, 10000);
+	char reboot_command[] = {0x86, 0x00, 0x00, 0x00, 0x00, 0x00, 0x08};
+	int response = usb_control_msg(serial_handle, 0x21, 0x20, 0, 0, reboot_command, sizeof reboot_command, 10000);
 
 	usb_release_interface(serial_handle, 0);
 	usb_close(serial_handle);


### PR DESCRIPTION
SET_LINE_REQUEST_TYPE (0x21) expects a 7 byte buffer: 4 bytes for
speed, 1 byte of 0 for 1 stop bit, 1 byte of 0 for no parity, and
1 byte of 8 for 8 data bits. Under Raspbian at least, sending a
single byte only caused a broken pipe error and the soft_reboot
always failed.