### PR TITLE
Add options --vid=<VID> --pid=<PID> --serial=<SERIAL> for soft reset with libusb

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Teensy Loader - Command Line Version#
+# Teensy Loader - Command Line Version with options to set VID, PID, and serial number
 
 The Teensy Loader is available in a command line version for advanced users who want to automate programming, typically using a Makefile. For most uses, the graphical version in Automatic Mode is much easier. 
 
@@ -60,6 +60,12 @@ Optional command line parameters:
 `-n` : No reboot after programming. After programming the hex file, do not reboot. HalfKay remains running. This option may be useful if you wish to program the code but do not intend for it to run until the Teensy is installed inside a system with its I/O pins connected.
 
 `-v` : Verbose output. Normally teensy_loader_cli prints only error messages if any operation fails. This enables verbose output, which can help with troubleshooting, or simply show you more status information.
+
+`--vid=<VID>` : (only with libusb) Specify the Vendor ID to match for sending the soft reset.
+
+`--pid=<PID>` : (only with libusb) Specify the Product ID to match for sending the soft reset.
+
+`--serial=<SERIAL>` : (only with libusb) Specify the serial number to match for sending the soft reset.
 
 ## System Specific Setup
 

--- a/teensy_loader_cli.c
+++ b/teensy_loader_cli.c
@@ -37,7 +37,7 @@ void usage(const char *err)
 {
 	if(err != NULL) fprintf(stderr, "%s\n\n", err);
 	fprintf(stderr,
-		"Usage: teensy_loader_cli --mcu=<MCU> [-w] [-h] [-n] [-b] [-v] <file.hex>\n"
+		"Usage: teensy_loader_cli --mcu=<MCU> [--vid=<VID>] [--pid=<PID>] [-w] [-h] [-n] [-b] [-v] <file.hex>\n"
 		"\t-w : Wait for device to appear\n"
 		"\t-r : Use hard reboot if device not online\n"
 		"\t-s : Use soft reboot if device not online (Teensy 3.x & 4.x)\n"
@@ -78,6 +78,8 @@ int reboot_after_programming = 1;
 int verbose = 0;
 int boot_only = 0;
 int code_size = 0, block_size = 0;
+int opt_vid = 0x16C0;
+int opt_pid = 0x0483;
 const char *filename=NULL;
 
 
@@ -334,7 +336,7 @@ int soft_reboot(void)
 {
 	usb_dev_handle *serial_handle = NULL;
 
-	serial_handle = open_usb_device(0x16C0, 0x0483);
+	serial_handle = open_usb_device(opt_vid, opt_pid);
 	if (!serial_handle) {
 		char *error = usb_strerror();
 		printf("Error opening USB device: %s\n", error);
@@ -1168,6 +1170,8 @@ void parse_options(int argc, char **argv)
 				if(strcasecmp(name, "help") == 0) usage(NULL);
 				else if(strcasecmp(name, "mcu") == 0) read_mcu(val);
 				else if(strcasecmp(name, "list-mcus") == 0) list_mcus();
+				else if(strcasecmp(name, "vid") == 0) opt_vid = strtoul(val, NULL, 16);
+				else if(strcasecmp(name, "pid") == 0) opt_pid = strtoul(val, NULL, 16);
 				else {
 					fprintf(stderr, "Unknown option \"%s\"\n\n", arg);
 					usage(NULL);


### PR DESCRIPTION
Hello,

I am aware that this is not the first pull request asking for that critical feature absolutely required to remotely update multiples boards connected to the same computer. The VID and PID options allow to control boards with custom USB descriptor. Tested on Debian 11 with 4 Teensy 4.1 board behind a external hub and each with custom USB composite descriptors (ACM + ACM + HID + HID).

The code only touch the soft reset for libusb. If you like the idea, feel free to extend that to other reset and libraries.

Best regards.
Jean-Christian