### PR TITLE
Revert "No need for CPP flags on linux"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ ifeq ($(OS), LINUX)  # also works on FreeBSD
 CC ?= gcc
 CFLAGS ?= -O2 -Wall
 teensy_loader_cli: teensy_loader_cli.c
-	$(CC) $(CFLAGS) -s -DUSE_LIBUSB -o teensy_loader_cli teensy_loader_cli.c -lusb $(LDFLAGS)
+	$(CC) $(CFLAGS) $(CPPFLAGS) -s -DUSE_LIBUSB -o teensy_loader_cli teensy_loader_cli.c -lusb $(LDFLAGS)
 
 
 else ifeq ($(OS), WINDOWS)


### PR DESCRIPTION
This pull request reverts PaulStoffregen/teensy_loader_cli#50, which I have noticed just now.

Support for CPPFLAGS was originally added by me in https://github.com/PaulStoffregen/teensy_loader_cli/pull/39, and then removed by @hmaarrfk’s PaulStoffregen/teensy_loader_cli#50 with the description “no need for CPP flags on linux”.

However, that was incorrect. **There is a need for CPPFLAGS on Linux**, specifically for example for Debian packaging, which passes additional hardening flags, as my original https://github.com/PaulStoffregen/teensy_loader_cli/pull/39 mentioned.

I verified this just now.

With CPPFLAGS, the build output is:
```
cc -g -O2 -ffile-prefix-map=/tmp/teensy-loader-cli-2.1=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -s -DUSE_LIBUSB -o teensy_loader_cli teensy_loader_cli.c -lusb -Wl,-z,relro -Wl,-z,now
```

Without CPPFLAGS, the build output is:
```
cc -g -O2 -ffile-prefix-map=/tmp/teensy-loader-cli-2.1=. -fstack-protector-strong -Wformat -Werror=format-security -s -DUSE_LIBUSB -o teensy_loader_cli teensy_loader_cli.c -lusb -Wl,-z,relro -Wl,-z,now
```

Note that `-D_FORTIFY_SOURCE=2` is missing when CPPFLAGS is not specified.