### PR TITLE
Making soft_reboot() work on more USB build flags than USB_SERIAL

### DIFF
--- a/teensy_loader_cli.c
+++ b/teensy_loader_cli.c
@@ -336,6 +336,9 @@ int soft_reboot(void)
 
 	serial_handle = open_usb_device(0x16C0, 0x0483);
 	if (!serial_handle) {
+		serial_handle = open_usb_device(0x16C0, 0x0489);
+	}
+	if (!serial_handle) {
 		char *error = usb_strerror();
 		printf("Error opening USB device: %s\n", error);
 		return 0;


### PR DESCRIPTION
Currently soft_reboot() only works on builds compiled with USB_SERIAL.

This commit updates the soft_reboot() to be able to reboot builds compiled with USB_MIDI_SERIAL, USB_MIDI4_SERIAL and USB_MIDI16_SERIAL.