### PR TITLE
increase teensy_write timeout to 2 seconds

### DIFF
--- a/teensy_loader_cli.c
+++ b/teensy_loader_cli.c
@@ -191,7 +191,7 @@ int main(int argc, char **argv)
 		} else {
 			die("Unknown code/block size\n");
 		}
-		r = teensy_write(buf, write_size, first_block ? 5.0 : 0.5);
+		r = teensy_write(buf, write_size, first_block ? 5.0 : 2.0);
 		if (!r) die("error writing to Teensy\n");
 		first_block = 0;
 	}


### PR DESCRIPTION
the loader did not work consistently with a timeout
of 0.5 for a new batch of the DVJ6B chips I got in.
Experimenting, a 1.0s timeout also did not work consistently,
but 2.0 has worked every time.