### PR TITLE
Makefile: Be flexible about locations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ ifeq ($(USE_LIBUSB), YES)
 CC ?= gcc
 CFLAGS ?= -O2 -Wall
 teensy_loader_cli: teensy_loader_cli.c
-	$(CC) $(CFLAGS) -s -DUSE_LIBUSB -DMACOSX -o teensy_loader_cli teensy_loader_cli.c -lusb -I /usr/local/include -L/usr/local/lib
+	$(CC) $(CFLAGS) -s -DUSE_LIBUSB -DMACOSX -o teensy_loader_cli teensy_loader_cli.c -lusb $(LDFLAGS)
 	 
 else
 CC ?= gcc


### PR DESCRIPTION
Managed to use it on OS X 10.4 (powerpc) to flash a teensy 2

```
bin/teensy_loader_cli -w --mcu=TEENSY2 /tmp/teensy_loader_cli-2.2/blink_slow_Teensy2.hex -v
Teensy Loader, Command Line, Version 2.2
Read "/tmp/teensy_loader_cli-2.2/blink_slow_Teensy2.hex": 2332 bytes, 7.2% usage
Waiting for Teensy device...
 (hint: press the reset button)
Found HalfKay Bootloader
Read "/tmp/teensy_loader_cli-2.2/blink_slow_Teensy2.hex": 2332 bytes, 7.2% usage
Programming...................
Booting
```