### PR TITLE
libusb: update package names in comment for RHEL/Fedora

### DIFF
--- a/teensy_loader_cli.c
+++ b/teensy_loader_cli.c
@@ -208,19 +208,19 @@ int main(int argc, char **argv)
 
 
 
-/****************************************************************/
-/*                                                              */
-/*             USB Access - libusb (Linux & FreeBSD)            */
-/*                                                              */
-/*  Uses libusb v0.1. To install:                               */
-/*  - [debian, ubuntu, mint] apt install libusb-dev             */
-/*  - [redhat, centos]       yum install libusb-devel           */
-/*  - [fedora]               dnf install libusb-devel           */
-/*  - [arch linux]           pacman -S libusb-compat            */
-/*  - [gentoo]               emerge dev-libs/libusb-compat      */
-/*                                                              */
-/*  - [freebsd]              seems to be preinstalled           */
-/****************************************************************/
+/*****************************************************************/
+/*                                                               */
+/*             USB Access - libusb (Linux & FreeBSD)             */
+/*                                                               */
+/*  Uses libusb v0.1. To install:                                */
+/*  - [debian, ubuntu, mint] apt install libusb-dev              */
+/*  - [redhat, centos]       yum install libusb-compat-0.1-devel */
+/*  - [fedora]               dnf install libusb-compat-0.1-devel */
+/*  - [arch linux]           pacman -S libusb-compat             */
+/*  - [gentoo]               emerge dev-libs/libusb-compat       */
+/*                                                               */
+/*  - [freebsd]              seems to be preinstalled            */
+/*****************************************************************/
 
 #if defined(USE_LIBUSB)
 


### PR DESCRIPTION
I had the same problem as #30 because I installed `libusb1-devel` on Fedora. The package `libusb-devel` does not exist anymore and `libusb-compat-0.1-devel` is required instead.

I also checked if the other distros required updating (using [pkgs.org](https://pkgs.org/search/?q=libusb) and the various' distros package listings) but it seems that only Fedora and RHEL were impacted.